### PR TITLE
use mamba instead of pip for dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/tests/CI_docker/context/environment_{{cookiecutter.project_slug}}.yml
+++ b/{{cookiecutter.project_slug}}/tests/CI_docker/context/environment_{{cookiecutter.project_slug}}.yml
@@ -6,28 +6,23 @@ channels: &id1
 dependencies:
   - python=3.*.*
   - pip
+  # setup requirements
+  - tox
+  # test requirements
+  - pytest
+  - pytest-cov
+  - urlchecker
+  # lint requirements
+  - flake8
+  - pycodestyle
+  - pydocstyle
+  - pylint
+  # doc requirements
+  - sphinx>=4.1.1
+  - sphinx-argparse
+  - sphinx_rtd_theme
+  - # deployment requirements
+  - twine
 
   - pip:
-    # setup requirements
-    - tox
-
-    # test requirements
-    - pytest
-    - pytest-cov
     - pytest-reporter-html1
-    - urlchecker
-
-    # lint requirements
-    - flake8
-    - pycodestyle
-    - pydocstyle
-    - pylint
-
-    # doc requirements
-    - sphinx>=4.1.1
-    - sphinx-argparse
-    - sphinx_autodoc_typehints
-    - sphinx_rtd_theme
-
-    # deployment requirements
-    - twine


### PR DESCRIPTION
use mamba instead of pip for the environment_{{cookiecutter.project_slug}}.yml